### PR TITLE
Auto updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This extension adds the following resource extra fields to CKAN resources:
 You'll need to add them to `ckan.extra_resource_fields` in your CKAN config:
 
 ```ini
-ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count activityinfo_user
+ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_progress activityinfo_error activityinfo_format activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count activityinfo_user
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -33,24 +33,64 @@ pip install git+https://github.com/okfn/ckanext-activityinfo@0.1.0#egg=ckanext-a
 
 Also, add `activityinfo` to the `ckan.plugins` setting in your CKAN config file.  
 
+## Automatic updates
+
+ActivityInfo resources can be configured to update automatically (daily or weekly) with a limited number of runs (1 to 20).
+These settings are available in the resource creation and edit forms.
+
+To enable automatic updates, you need to set up a cron job (or equivalent scheduler) that runs the `sync-auto-updates` CLI command periodically.
+The command checks all resources that are due for an update, enqueues background download jobs using each resource's original creator API key, and exits.
+
+### Cron
+
+As example.
+Run the sync command at a frequency that matches your shortest update interval. If you have daily resources, run it at least once a day:
+
+```bash
+# Run every 6 hours (covers both daily and weekly resources)
+0 */6 * * * /usr/bin/ckan -c /etc/ckan/production.ini activityinfo resources sync-auto-updates >> /var/log/ckan/activityinfo-sync.log 2>&1
+```
+
+### Yacron
+
+```yaml
+jobs:
+  - name: activityinfo-sync
+    command: ckan -c /etc/ckan/production.ini activityinfo resources sync-auto-updates
+    schedule: "0 */6 * * *"
+```
+
+### Options
+
+```bash
+# Preview what would be updated without actually running
+ckan activityinfo resources sync-auto-updates --dry-run
+
+# Enable verbose logging
+ckan activityinfo resources sync-auto-updates -v
+```
+
 ## Resource extra fields
 
 This extension adds the following resource extra fields to CKAN resources:
  - `activityinfo_form_id`: the ActivityInfo form ID
  - `activityinfo_database_id`: the ActivityInfo database ID
- - `activityinfo_status`: the download status (e.g. 'pending', 'in_progress', 'complete', 'error')
+ - `activityinfo_status`: the download status (`pending`, `exporting`, `downloading`, `complete`, `error`)
  - `activityinfo_progress`: the download progress (0-100)
  - `activityinfo_error`: any error message if the download failed
- - `activityinfo_format`: the format of the downloaded data (e.g. 'csv', 'xls')
+ - `activityinfo_format`: the format of the downloaded data (e.g. `csv`, `xlsx`)
  - `activityinfo_form_label`: the label of the ActivityInfo form
+ - `activityinfo_auto_update`: automatic update frequency (`never`, `daily`, `weekly`)
+ - `activityinfo_auto_update_runs`: how many times automatic updates should run (1-20)
+ - `activityinfo_last_updated`: ISO timestamp of the last automatic update
+ - `activityinfo_auto_update_count`: how many automatic updates have been completed so far
+ - `activityinfo_user`: the CKAN username who created the resource (used for automatic update authentication)
 
-You'll need to add them to `ckan.extra_resource_fields` to allow searching resources (action `resource_search`) by these fields.  
+You'll need to add them to `ckan.extra_resource_fields` in your CKAN config:
 
-```bash
-ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status
+```ini
+ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count activityinfo_user
 ```
-
-You will get error is extra fields are not added to `ckan.extra_resource_fields` and you try to search resources by these fields. For example:
 
 
 ## Config settings

--- a/ckanext/activityinfo/actions/resource.py
+++ b/ckanext/activityinfo/actions/resource.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from ckan.plugins import toolkit
 from ckanext.activityinfo.jobs.download import download_activityinfo_resource
@@ -87,6 +88,10 @@ def resource_create(original_action, context, data_dict):
 
         # Store which user created this resource (for auto-update auth)
         resource_data['activityinfo_user'] = user
+
+        # Set the timestamp so the first auto-update waits the full interval
+        resource_data['activityinfo_last_updated'] = datetime.now(timezone.utc).isoformat()
+        resource_data['activityinfo_auto_update_count'] = 0
 
         # Set name with format suffix if multiple formats
         if len(formats) > 1:

--- a/ckanext/activityinfo/actions/resource.py
+++ b/ckanext/activityinfo/actions/resource.py
@@ -2,11 +2,10 @@ import logging
 
 from ckan.plugins import toolkit
 from ckanext.activityinfo.jobs.download import download_activityinfo_resource
+from ckanext.activityinfo.utils import VALID_AUTO_UPDATE_VALUES
 
 
 log = logging.getLogger(__name__)
-
-VALID_AUTO_UPDATE_VALUES = ('never', 'daily', 'weekly')
 
 
 def _validate_auto_update_fields(data_dict):

--- a/ckanext/activityinfo/actions/resource.py
+++ b/ckanext/activityinfo/actions/resource.py
@@ -85,6 +85,9 @@ def resource_create(original_action, context, data_dict):
         resource_data['activityinfo_progress'] = 0
         resource_data['activityinfo_error'] = ''
 
+        # Store which user created this resource (for auto-update auth)
+        resource_data['activityinfo_user'] = user
+
         # Set name with format suffix if multiple formats
         if len(formats) > 1:
             resource_data['name'] = f"{form_label} ({format_type.upper()})"

--- a/ckanext/activityinfo/cli/__init__.py
+++ b/ckanext/activityinfo/cli/__init__.py
@@ -11,31 +11,31 @@ def activityinfo():
     pass
 
 
-@activityinfo.group(short_help='ActivityInfo databases')
-def databases():
+@activityinfo.group(name='databases', short_help='ActivityInfo databases')
+def databases_group():
     pass
 
 
-@activityinfo.group(short_help='ActivityInfo forms')
-def forms():
+@activityinfo.group(name='forms', short_help='ActivityInfo forms')
+def forms_group():
     pass
 
 
-@activityinfo.group(short_help='ActivityInfo resources')
-def resources():
+@activityinfo.group(name='resources', short_help='ActivityInfo resources')
+def resources_group():
     pass
 
 
 # ckan activityinfo databases list -t xxxxxx
-databases.add_command(cli_databases.get_activityinfo_databases_list)
+databases_group.add_command(cli_databases.get_activityinfo_databases_list)
 
 # ckan activityinfo forms list -t xxxxx -d yyyyy [-s]
-forms.add_command(cli_forms.get_activityinfo_forms_list)
+forms_group.add_command(cli_forms.get_activityinfo_forms_list)
 
 # ckan activityinfo resources update-activity-info-resource -r xxxxx -u username
 # The user should have permissions to access the ActivityInfo API (API key) and the resource to update
-resources.add_command(cli_resources.update_activityinfo_resource)
+resources_group.add_command(cli_resources.update_activityinfo_resource)
 
 # ckan activityinfo resources sync-auto-updates [--dry-run] [-v]
 # Find and update all resources due for automatic update (meant for cron)
-resources.add_command(cli_resources.sync_auto_updates)
+resources_group.add_command(cli_resources.sync_auto_updates)

--- a/ckanext/activityinfo/cli/__init__.py
+++ b/ckanext/activityinfo/cli/__init__.py
@@ -35,3 +35,7 @@ forms.add_command(cli_forms.get_activityinfo_forms_list)
 # ckan activityinfo resources update-activity-info-resource -r xxxxx -u username
 # The user should have permissions to access the ActivityInfo API (API key) and the resource to update
 resources.add_command(cli_resources.update_activityinfo_resource)
+
+# ckan activityinfo resources sync-auto-updates [--dry-run] [-v]
+# Find and update all resources due for automatic update (meant for cron)
+resources.add_command(cli_resources.sync_auto_updates)

--- a/ckanext/activityinfo/cli/databases.py
+++ b/ckanext/activityinfo/cli/databases.py
@@ -1,6 +1,7 @@
 import logging
 import click
 from requests.exceptions import HTTPError
+from ckanext.activityinfo.cli.logs import setup_cli_logging
 from ckanext.activityinfo.data.base import ActivityInfoClient
 from ckanext.activityinfo.exceptions import ActivityInfoConnectionError
 
@@ -16,6 +17,8 @@ log = logging.getLogger(__name__)
 @click.option('-v', '--verbose', count=True)
 def get_activityinfo_databases_list(activityinfo_token, verbose):
     """ Get a list with all ActivityInfo databases for a user. """
+
+    handler, logger = setup_cli_logging(verbose)
 
     click.secho('Getting ActivityInfo databases')
     aic = ActivityInfoClient(api_key=activityinfo_token)
@@ -39,3 +42,4 @@ def get_activityinfo_databases_list(activityinfo_token, verbose):
             click.secho(f"  ownerId: {database.get('ownerId', 'N/A')}")
 
     click.secho(f'Total ActivityInfo databases: {total}')
+    logger.removeHandler(handler)

--- a/ckanext/activityinfo/cli/forms.py
+++ b/ckanext/activityinfo/cli/forms.py
@@ -1,6 +1,7 @@
 import logging
 import click
 from requests.exceptions import HTTPError
+from ckanext.activityinfo.cli.logs import setup_cli_logging
 from ckanext.activityinfo.data.base import ActivityInfoClient
 from ckanext.activityinfo.exceptions import ActivityInfoConnectionError
 
@@ -18,6 +19,8 @@ log = logging.getLogger(__name__)
 @click.option('-v', '--verbose', count=True)
 def get_activityinfo_forms_list(activityinfo_token, database_id, include_sub_forms, verbose):
     """ Get a list with all forms and sub-forms in ActivityInfo. """
+
+    handler, logger = setup_cli_logging(verbose)
 
     click.secho('Getting ActivityInfo forms')
     aic = ActivityInfoClient(api_key=activityinfo_token)
@@ -51,3 +54,4 @@ def get_activityinfo_forms_list(activityinfo_token, database_id, include_sub_for
     total_sub_forms = len(forms.get('sub_forms', []))
 
     click.secho(f'Total ActivityInfo forms: {total_forms}, sub-forms: {total_sub_forms}')
+    logger.removeHandler(handler)

--- a/ckanext/activityinfo/cli/logs.py
+++ b/ckanext/activityinfo/cli/logs.py
@@ -1,0 +1,20 @@
+import logging
+import click
+
+
+def setup_cli_logging(verbose=False, logger_name='ckanext.activityinfo'):
+    """Attach a logging handler that forwards app logs to click.echo.
+
+    By default captures everything under the extension's package root so CLI
+    commands expose HTTP client activity, job progress, selector decisions,
+    etc. Returns (handler, logger) so the caller can remove the handler when
+    done.
+    """
+    logger = logging.getLogger(logger_name)
+    handler = logging.Handler()
+    handler.emit = lambda record: click.echo(f"  {handler.format(record)}")
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.addHandler(handler)
+    logger.setLevel(handler.level)
+    return handler, logger

--- a/ckanext/activityinfo/cli/resources.py
+++ b/ckanext/activityinfo/cli/resources.py
@@ -1,6 +1,25 @@
 import logging
+from datetime import datetime, timezone
+
 import click
+from ckan.plugins import toolkit
 from ckanext.activityinfo.jobs.download import download_activityinfo_resource
+from ckanext.activityinfo.utils import get_resources_due_for_auto_update
+
+
+def _setup_download_logging(verbose=False):
+    """Set up a logging handler that forwards download logs to click.echo.
+
+    Returns (handler, logger) so the caller can remove the handler when done.
+    """
+    download_logger = logging.getLogger('ckanext.activityinfo.jobs.download')
+    handler = logging.Handler()
+    handler.emit = lambda record: click.echo(f"  {handler.format(record)}")
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+    download_logger.addHandler(handler)
+    download_logger.setLevel(handler.level)
+    return handler, download_logger
 
 
 @click.command(
@@ -13,14 +32,7 @@ from ckanext.activityinfo.jobs.download import download_activityinfo_resource
 def update_activityinfo_resource(resource_id, user_name, verbose):
     """ Update a single ActivityInfo resource. """
 
-    # Temporarily attach a handler that forwards log messages to click.echo
-    download_logger = logging.getLogger('ckanext.activityinfo.jobs.download')
-    handler = logging.Handler()
-    handler.emit = lambda record: click.echo(handler.format(record))
-    handler.setFormatter(logging.Formatter('%(message)s'))
-    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
-    download_logger.addHandler(handler)
-    download_logger.setLevel(handler.level)
+    handler, download_logger = _setup_download_logging(verbose)
 
     click.echo('Updating ActivityInfo resource')
     try:
@@ -28,3 +40,103 @@ def update_activityinfo_resource(resource_id, user_name, verbose):
         click.echo('ActivityInfo resource updated successfully')
     finally:
         download_logger.removeHandler(handler)
+
+
+@click.command(
+    'sync-auto-updates',
+    short_help='Sync all ActivityInfo resources due for automatic update'
+)
+@click.option('-v', '--verbose', count=True)
+@click.option(
+    '--dry-run', is_flag=True, default=False,
+    help='Show what would be updated without actually running updates'
+)
+def sync_auto_updates(verbose, dry_run):
+    """Find and update all ActivityInfo resources due for automatic update.
+
+    This command is meant to be run from cron. It checks all resources with
+    activityinfo_auto_update set to 'daily' or 'weekly', verifies timing
+    and run limits, and triggers downloads for those that are due.
+
+    Each resource is updated using the CKAN user who originally created it
+    (stored in the activityinfo_user field).
+    """
+    click.echo("Checking for ActivityInfo resources due for auto-update...")
+
+    due_resources = get_resources_due_for_auto_update()
+
+    if not due_resources:
+        click.echo("No resources due for update.")
+        return
+
+    click.echo(f"Found {len(due_resources)} resource(s) due for update.")
+
+    if dry_run:
+        for res in due_resources:
+            count = res.get('activityinfo_auto_update_count', 0)
+            max_runs = res.get('activityinfo_auto_update_runs', 1)
+            user = res.get('activityinfo_user', '?')
+            click.echo(
+                f"  [DRY RUN] {res['id']} - "
+                f"{res.get('activityinfo_form_label', '?')} "
+                f"({res.get('activityinfo_auto_update')}, "
+                f"run {count}/{max_runs}, user: {user})"
+            )
+        return
+
+    enqueued = 0
+    failed = 0
+    skipped = 0
+
+    for res in due_resources:
+        resource_id = res['id']
+        form_label = res.get('activityinfo_form_label', resource_id)
+        current_count = int(res.get('activityinfo_auto_update_count', 0) or 0)
+        max_runs = int(res.get('activityinfo_auto_update_runs', 1) or 1)
+        user_name = res.get('activityinfo_user')
+
+        if not user_name:
+            click.echo(
+                f"\nSkipping: {form_label} ({resource_id}) "
+                f"- no activityinfo_user set"
+            )
+            skipped += 1
+            continue
+
+        click.echo(
+            f"\nUpdating: {form_label} ({resource_id}) "
+            f"- run {current_count + 1}/{max_runs}, user: {user_name}"
+        )
+
+        try:
+            result = toolkit.get_action('act_info_update_resource_file')(
+                {'user': user_name, 'ignore_auth': True},
+                {'resource_id': resource_id}
+            )
+
+            # Update the counter and timestamp now that the job is enqueued
+            # No matter if the job succeeds or fails, we count this as a run to avoid infinite retries on failures
+            # Errors will be registered with the activityinfo_error resource extra field
+            now_iso = datetime.now(timezone.utc).isoformat()
+            toolkit.get_action('resource_patch')(
+                {'user': user_name, 'ignore_auth': True},
+                {
+                    'id': resource_id,
+                    'activityinfo_last_updated': now_iso,
+                    'activityinfo_auto_update_count': current_count + 1,
+                }
+            )
+
+            job_id = result.get('job_id', '?')
+            click.echo(
+                f"  OK - job {job_id} enqueued "
+                f"(run {current_count + 1}/{max_runs})"
+            )
+            enqueued += 1
+
+        except Exception as e:
+            click.echo(f"  FAILED - {e}", err=True)
+            failed += 1
+            continue
+
+    click.echo(f"\nSync complete: {enqueued} enqueued, {failed} failed, {skipped} skipped.")

--- a/ckanext/activityinfo/cli/resources.py
+++ b/ckanext/activityinfo/cli/resources.py
@@ -1,10 +1,7 @@
-from datetime import datetime, timezone
-
 import click
-from ckan.plugins import toolkit
 from ckanext.activityinfo.jobs.download import download_activityinfo_resource
 from ckanext.activityinfo.cli.logs import setup_cli_logging
-from ckanext.activityinfo.utils import get_resources_due_for_auto_update
+from ckanext.activityinfo.utils import run_sync_auto_updates
 
 
 @click.command(
@@ -49,86 +46,9 @@ def sync_auto_updates(verbose, dry_run):
     (stored in the activityinfo_user field).
     """
     handler, logger = setup_cli_logging(verbose)
-
-    click.echo("Checking for ActivityInfo resources due for auto-update...")
-
-    due_resources = get_resources_due_for_auto_update()
-
-    if not due_resources:
-        click.echo("No resources due for update.")
-        logger.removeHandler(handler)
-        return
-
-    click.echo(f"Found {len(due_resources)} resource(s) due for update.")
-
-    if dry_run:
-        for res in due_resources:
-            count = res.get('activityinfo_auto_update_count', 0)
-            max_runs = res.get('activityinfo_auto_update_runs', 1)
-            user = res.get('activityinfo_user', '?')
-            click.echo(
-                f"  [DRY RUN] {res['id']} - "
-                f"{res.get('activityinfo_form_label', '?')} "
-                f"({res.get('activityinfo_auto_update')}, "
-                f"run {count}/{max_runs}, user: {user})"
-            )
-        logger.removeHandler(handler)
-        return
-
-    enqueued = 0
-    failed = 0
-    skipped = 0
-
-    for res in due_resources:
-        resource_id = res['id']
-        form_label = res.get('activityinfo_form_label', resource_id)
-        current_count = int(res.get('activityinfo_auto_update_count', 0) or 0)
-        max_runs = int(res.get('activityinfo_auto_update_runs', 1) or 1)
-        user_name = res.get('activityinfo_user')
-
-        if not user_name:
-            click.echo(
-                f"\nSkipping: {form_label} ({resource_id}) "
-                f"- no activityinfo_user set"
-            )
-            skipped += 1
-            continue
-
-        click.echo(
-            f"\nUpdating: {form_label} ({resource_id}) "
-            f"- run {current_count + 1}/{max_runs}, user: {user_name}"
-        )
-
-        try:
-            result = toolkit.get_action('act_info_update_resource_file')(
-                {'user': user_name, 'ignore_auth': True},
-                {'resource_id': resource_id}
-            )
-
-            # Update the counter and timestamp now that the job is enqueued
-            # No matter if the job succeeds or fails, we count this as a run to avoid infinite retries on failures
-            # Errors will be registered with the activityinfo_error resource extra field
-            now_iso = datetime.now(timezone.utc).isoformat()
-            toolkit.get_action('resource_patch')(
-                {'user': user_name, 'ignore_auth': True},
-                {
-                    'id': resource_id,
-                    'activityinfo_last_updated': now_iso,
-                    'activityinfo_auto_update_count': current_count + 1,
-                }
-            )
-
-            job_id = result.get('job_id', '?')
-            click.echo(
-                f"  OK - job {job_id} enqueued "
-                f"(run {current_count + 1}/{max_runs})"
-            )
-            enqueued += 1
-
-        except Exception as e:
-            click.echo(f"  FAILED - {e}", err=True)
-            failed += 1
-            continue
-
-    click.echo(f"\nSync complete: {enqueued} enqueued, {failed} failed, {skipped} skipped.")
+    summary = run_sync_auto_updates(dry_run=dry_run)
+    click.echo(
+        f"\nSync complete: {summary['enqueued']} enqueued, "
+        f"{summary['failed']} failed, {summary['skipped']} skipped."
+    )
     logger.removeHandler(handler)

--- a/ckanext/activityinfo/cli/resources.py
+++ b/ckanext/activityinfo/cli/resources.py
@@ -38,6 +38,8 @@ def update_activityinfo_resource(resource_id, user_name, verbose):
     try:
         download_activityinfo_resource(resource_id=resource_id, user=user_name)
         click.echo('ActivityInfo resource updated successfully')
+    except Exception as e:
+        raise click.ClickException(str(e))
     finally:
         download_logger.removeHandler(handler)
 

--- a/ckanext/activityinfo/cli/resources.py
+++ b/ckanext/activityinfo/cli/resources.py
@@ -1,25 +1,10 @@
-import logging
 from datetime import datetime, timezone
 
 import click
 from ckan.plugins import toolkit
 from ckanext.activityinfo.jobs.download import download_activityinfo_resource
+from ckanext.activityinfo.cli.logs import setup_cli_logging
 from ckanext.activityinfo.utils import get_resources_due_for_auto_update
-
-
-def _setup_download_logging(verbose=False):
-    """Set up a logging handler that forwards download logs to click.echo.
-
-    Returns (handler, logger) so the caller can remove the handler when done.
-    """
-    download_logger = logging.getLogger('ckanext.activityinfo.jobs.download')
-    handler = logging.Handler()
-    handler.emit = lambda record: click.echo(f"  {handler.format(record)}")
-    handler.setFormatter(logging.Formatter('%(message)s'))
-    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
-    download_logger.addHandler(handler)
-    download_logger.setLevel(handler.level)
-    return handler, download_logger
 
 
 @click.command(
@@ -32,7 +17,7 @@ def _setup_download_logging(verbose=False):
 def update_activityinfo_resource(resource_id, user_name, verbose):
     """ Update a single ActivityInfo resource. """
 
-    handler, download_logger = _setup_download_logging(verbose)
+    handler, logger = setup_cli_logging(verbose)
 
     click.echo('Updating ActivityInfo resource')
     try:
@@ -40,8 +25,8 @@ def update_activityinfo_resource(resource_id, user_name, verbose):
         click.echo('ActivityInfo resource updated successfully')
     except Exception as e:
         raise click.ClickException(str(e))
-    finally:
-        download_logger.removeHandler(handler)
+
+    logger.removeHandler(handler)
 
 
 @click.command(
@@ -63,12 +48,15 @@ def sync_auto_updates(verbose, dry_run):
     Each resource is updated using the CKAN user who originally created it
     (stored in the activityinfo_user field).
     """
+    handler, logger = setup_cli_logging(verbose)
+
     click.echo("Checking for ActivityInfo resources due for auto-update...")
 
     due_resources = get_resources_due_for_auto_update()
 
     if not due_resources:
         click.echo("No resources due for update.")
+        logger.removeHandler(handler)
         return
 
     click.echo(f"Found {len(due_resources)} resource(s) due for update.")
@@ -84,6 +72,7 @@ def sync_auto_updates(verbose, dry_run):
                 f"({res.get('activityinfo_auto_update')}, "
                 f"run {count}/{max_runs}, user: {user})"
             )
+        logger.removeHandler(handler)
         return
 
     enqueued = 0
@@ -142,3 +131,4 @@ def sync_auto_updates(verbose, dry_run):
             continue
 
     click.echo(f"\nSync complete: {enqueued} enqueued, {failed} failed, {skipped} skipped.")
+    logger.removeHandler(handler)

--- a/ckanext/activityinfo/templates/package/snippets/resource_upload_field.html
+++ b/ckanext/activityinfo/templates/package/snippets/resource_upload_field.html
@@ -111,6 +111,8 @@
         <input type="hidden" name="activityinfo_progress" value="{{ data.get('activityinfo_progress', 0) }}" />
         <input type="hidden" name="activityinfo_error" value="{{ data.get('activityinfo_error', '') }}" />
         <input type="hidden" name="activityinfo_format" value="{{ data.get('activityinfo_format', '') }}" />
+        <input type="hidden" name="activityinfo_last_updated" value="{{ data.get('activityinfo_last_updated', '') }}" />
+        <input type="hidden" name="activityinfo_auto_update_count" value="{{ data.get('activityinfo_auto_update_count', 0) }}" />
     {% else %}
         {# we only allow to clean and change upload for non-activityinfo resources #}
         {{ super() }}

--- a/ckanext/activityinfo/templates/package/snippets/resource_upload_field.html
+++ b/ckanext/activityinfo/templates/package/snippets/resource_upload_field.html
@@ -113,6 +113,7 @@
         <input type="hidden" name="activityinfo_format" value="{{ data.get('activityinfo_format', '') }}" />
         <input type="hidden" name="activityinfo_last_updated" value="{{ data.get('activityinfo_last_updated', '') }}" />
         <input type="hidden" name="activityinfo_auto_update_count" value="{{ data.get('activityinfo_auto_update_count', 0) }}" />
+        <input type="hidden" name="activityinfo_user" value="{{ data.get('activityinfo_user', '') }}" />
     {% else %}
         {# we only allow to clean and change upload for non-activityinfo resources #}
         {{ super() }}

--- a/ckanext/activityinfo/tests/factories.py
+++ b/ckanext/activityinfo/tests/factories.py
@@ -25,3 +25,4 @@ class ActivityInfoResource(factories.Resource):
     activityinfo_auto_update_runs = 1
     activityinfo_last_updated = ''
     activityinfo_auto_update_count = 0
+    activityinfo_user = ''

--- a/ckanext/activityinfo/tests/factories.py
+++ b/ckanext/activityinfo/tests/factories.py
@@ -23,3 +23,5 @@ class ActivityInfoResource(factories.Resource):
     activityinfo_format = 'csv'
     activityinfo_auto_update = 'never'
     activityinfo_auto_update_runs = 1
+    activityinfo_last_updated = ''
+    activityinfo_auto_update_count = 0

--- a/ckanext/activityinfo/tests/test_cli_resources.py
+++ b/ckanext/activityinfo/tests/test_cli_resources.py
@@ -1,6 +1,7 @@
 """Tests for CLI resource commands (update-activity-info-resource, sync-auto-updates)."""
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -13,10 +14,6 @@ from ckanext.activityinfo.cli.resources import (
     sync_auto_updates,
 )
 from ckanext.activityinfo.tests import factories
-
-# Captured BEFORE any @patch of toolkit.get_action so tests can call the real
-# action dispatcher without re-entering the mock (which causes recursion).
-_REAL_GET_ACTION = toolkit.get_action
 
 
 @pytest.fixture
@@ -123,8 +120,7 @@ class TestSyncAutoUpdatesCLI:
         assert result.exit_code == 0
         assert 'No resources due for update' in result.output
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_dry_run_shows_resources_without_updating(self, mock_get_action, setup_data):
+    def test_dry_run_shows_resources_without_updating(self, setup_data):
         """Dry run should list due resources but not enqueue jobs."""
         user_name = setup_data.activityinfo_user['name']
         resource = factories.ActivityInfoResource(
@@ -135,16 +131,21 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, ['--dry-run'])
+        fake_update = mock.MagicMock()
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, ['--dry-run'])
+
         assert result.exit_code == 0
         assert 'DRY RUN' in result.output
         assert resource['id'] in result.output
         assert user_name in result.output
-        mock_get_action.assert_not_called()
+        fake_update.assert_not_called()
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_skips_resource_without_activityinfo_user(self, mock_get_action, setup_data):
+    def test_skips_resource_without_activityinfo_user(self, setup_data):
         """Resources without activityinfo_user should be skipped."""
         factories.ActivityInfoResource(
             activityinfo_auto_update='daily',
@@ -154,14 +155,19 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user='',
         )
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
+        fake_update = mock.MagicMock()
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
+
         assert '1 skipped' in result.output
         assert 'no activityinfo_user set' in result.output
-        mock_get_action.assert_not_called()
+        fake_update.assert_not_called()
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_enqueues_job_for_due_resource(self, mock_get_action, setup_data):
+    def test_enqueues_job_for_due_resource(self, setup_data):
         """Due resources should be enqueued via act_info_update_resource_file."""
         user_name = setup_data.activityinfo_user['name']
         resource = factories.ActivityInfoResource(
@@ -172,24 +178,22 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        original_get_action = _REAL_GET_ACTION
         action_calls = []
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                def fake_action(ctx, dd):
-                    action_calls.append({
-                        'user': ctx.get('user'),
-                        'resource_id': dd.get('resource_id'),
-                    })
-                    return {'job_id': 'test-job-123', 'resource_id': dd['resource_id']}
-                return fake_action
-            return original_get_action(action_name)
+        def fake_update(ctx, dd):
+            action_calls.append({
+                'user': ctx.get('user'),
+                'resource_id': dd.get('resource_id'),
+            })
+            return {'job_id': 'test-job-123', 'resource_id': dd['resource_id']}
 
-        mock_get_action.side_effect = selective_mock
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert result.exit_code == 0
         assert '1 enqueued' in result.output
         assert 'test-job-123' in result.output
@@ -198,8 +202,7 @@ class TestSyncAutoUpdatesCLI:
         assert action_calls[0]['user'] == user_name
         assert action_calls[0]['resource_id'] == resource['id']
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_increments_counter_after_enqueue(self, mock_get_action, setup_data):
+    def test_increments_counter_after_enqueue(self, setup_data):
         """Counter and timestamp should be updated after successful enqueue."""
         user_name = setup_data.activityinfo_user['name']
         before = datetime.now(timezone.utc)
@@ -211,27 +214,24 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        original_get_action = _REAL_GET_ACTION
+        def fake_update(ctx, dd):
+            return {'job_id': 'j', 'resource_id': dd['resource_id']}
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                return lambda ctx, dd: {'job_id': 'j', 'resource_id': dd['resource_id']}
-            return original_get_action(action_name)
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            runner.invoke(sync_auto_updates, [])
 
-        mock_get_action.side_effect = selective_mock
-
-        runner = CliRunner()
-        runner.invoke(sync_auto_updates, [])
-
-        updated = original_get_action('resource_show')(
+        updated = toolkit.get_action('resource_show')(
             {'ignore_auth': True}, {'id': resource['id']}
         )
         assert int(updated['activityinfo_auto_update_count']) == 3
         last_updated = datetime.fromisoformat(updated['activityinfo_last_updated'])
         assert last_updated >= before
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_counter_unchanged_on_enqueue_failure(self, mock_get_action, setup_data):
+    def test_counter_unchanged_on_enqueue_failure(self, setup_data):
         """If enqueuing fails, counter should not be incremented."""
         user_name = setup_data.activityinfo_user['name']
         resource = factories.ActivityInfoResource(
@@ -242,27 +242,25 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        original_get_action = _REAL_GET_ACTION
+        def fake_update(ctx, dd):
+            raise Exception("Connection refused")
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                raise Exception("Connection refused")
-            return original_get_action(action_name)
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        mock_get_action.side_effect = selective_mock
-
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert '1 failed' in result.output
         assert 'Connection refused' in result.output
 
-        updated = original_get_action('resource_show')(
+        updated = toolkit.get_action('resource_show')(
             {'ignore_auth': True}, {'id': resource['id']}
         )
         assert int(updated['activityinfo_auto_update_count']) == 2
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_per_resource_user_isolation(self, mock_get_action, setup_data):
+    def test_per_resource_user_isolation(self, setup_data):
         """Each resource should be updated using its own activityinfo_user."""
         user_a = setup_data.activityinfo_user['name']
         user_b = factories.ActivityInfoUser()['name']
@@ -283,25 +281,22 @@ class TestSyncAutoUpdatesCLI:
         )
 
         users_called = []
-        original_get_action = _REAL_GET_ACTION
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                def fake_action(ctx, dd):
-                    users_called.append(ctx.get('user'))
-                    return {'job_id': 'j', 'resource_id': dd['resource_id']}
-                return fake_action
-            return original_get_action(action_name)
+        def fake_update(ctx, dd):
+            users_called.append(ctx.get('user'))
+            return {'job_id': 'j', 'resource_id': dd['resource_id']}
 
-        mock_get_action.side_effect = selective_mock
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert '2 enqueued' in result.output
         assert set(users_called) == {user_a, user_b}
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_mixed_success_and_failure(self, mock_get_action, setup_data):
+    def test_mixed_success_and_failure(self, setup_data):
         """Summary should correctly count mixed results."""
         user_name = setup_data.activityinfo_user['name']
 
@@ -329,28 +324,25 @@ class TestSyncAutoUpdatesCLI:
         )
 
         call_count = [0]
-        original_get_action = _REAL_GET_ACTION
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                def fake_action(ctx, dd):
-                    call_count[0] += 1
-                    if call_count[0] == 2:
-                        raise Exception("Boom")
-                    return {'job_id': 'j', 'resource_id': dd['resource_id']}
-                return fake_action
-            return original_get_action(action_name)
+        def fake_update(ctx, dd):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise Exception("Boom")
+            return {'job_id': 'j', 'resource_id': dd['resource_id']}
 
-        mock_get_action.side_effect = selective_mock
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert '1 enqueued' in result.output
         assert '1 failed' in result.output
         assert '1 skipped' in result.output
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_recently_created_resource_not_due(self, mock_get_action, setup_data):
+    def test_recently_created_resource_not_due(self, setup_data):
         """A resource created just now (with last_updated set) should not be due."""
         user_name = setup_data.activityinfo_user['name']
         now = datetime.now(timezone.utc).isoformat()
@@ -362,8 +354,14 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
+        fake_update = mock.MagicMock()
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
+
         assert result.exit_code == 0
         assert 'No resources due for update' in result.output
-        mock_get_action.assert_not_called()
+        fake_update.assert_not_called()

--- a/ckanext/activityinfo/tests/test_cli_resources.py
+++ b/ckanext/activityinfo/tests/test_cli_resources.py
@@ -14,6 +14,10 @@ from ckanext.activityinfo.cli.resources import (
 )
 from ckanext.activityinfo.tests import factories
 
+# Captured BEFORE any @patch of toolkit.get_action so tests can call the real
+# action dispatcher without re-entering the mock (which causes recursion).
+_REAL_GET_ACTION = toolkit.get_action
+
 
 @pytest.fixture
 def setup_data():
@@ -168,7 +172,7 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
         action_calls = []
 
         def selective_mock(action_name):
@@ -207,7 +211,7 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':
@@ -238,7 +242,7 @@ class TestSyncAutoUpdatesCLI:
             activityinfo_user=user_name,
         )
 
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':
@@ -279,7 +283,7 @@ class TestSyncAutoUpdatesCLI:
         )
 
         users_called = []
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':
@@ -325,7 +329,7 @@ class TestSyncAutoUpdatesCLI:
         )
 
         call_count = [0]
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':

--- a/ckanext/activityinfo/tests/test_cli_resources.py
+++ b/ckanext/activityinfo/tests/test_cli_resources.py
@@ -1,0 +1,365 @@
+"""Tests for CLI resource commands (update-activity-info-resource, sync-auto-updates)."""
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from ckan.plugins import toolkit
+from ckantoolkit.tests import factories as ckan_factories
+
+from ckanext.activityinfo.cli.resources import (
+    update_activityinfo_resource,
+    sync_auto_updates,
+)
+from ckanext.activityinfo.tests import factories
+
+
+@pytest.fixture
+def setup_data():
+    obj = SimpleNamespace()
+    obj.activityinfo_user = factories.ActivityInfoUser()
+    obj.regular_user = ckan_factories.UserWithToken()
+    return obj
+
+
+# ---- update-activity-info-resource ----
+
+@pytest.mark.usefixtures("clean_db")
+class TestUpdateActivityInfoResourceCLI:
+    """Tests for the update-activity-info-resource CLI command."""
+
+    @patch('ckanext.activityinfo.cli.resources.download_activityinfo_resource')
+    def test_success(self, mock_download, setup_data):
+        """Successful update should show success message."""
+        resource = factories.ActivityInfoResource()
+        user_name = setup_data.activityinfo_user['name']
+
+        runner = CliRunner()
+        result = runner.invoke(update_activityinfo_resource, [
+            '-r', resource['id'], '-u', user_name
+        ])
+
+        assert result.exit_code == 0
+        assert 'Updating ActivityInfo resource' in result.output
+        assert 'updated successfully' in result.output
+        mock_download.assert_called_once_with(
+            resource_id=resource['id'], user=user_name
+        )
+
+    @patch('ckanext.activityinfo.cli.resources.download_activityinfo_resource')
+    def test_download_failure_propagates(self, mock_download, setup_data):
+        """If download raises, the exception should propagate."""
+        mock_download.side_effect = ValueError("No API key configured")
+        resource = factories.ActivityInfoResource()
+        user_name = setup_data.activityinfo_user['name']
+
+        runner = CliRunner()
+        result = runner.invoke(update_activityinfo_resource, [
+            '-r', resource['id'], '-u', user_name
+        ])
+
+        assert result.exit_code != 0
+        assert 'No API key configured' in result.output
+
+    def test_missing_resource_id(self, setup_data):
+        """Missing --resource-id should fail."""
+        runner = CliRunner()
+        result = runner.invoke(update_activityinfo_resource, [
+            '-u', 'someuser'
+        ])
+        assert result.exit_code != 0
+        assert 'Missing option' in result.output or 'required' in result.output.lower()
+
+    def test_missing_user_name(self, setup_data):
+        """Missing --user-name should fail."""
+        runner = CliRunner()
+        result = runner.invoke(update_activityinfo_resource, [
+            '-r', 'some-id'
+        ])
+        assert result.exit_code != 0
+        assert 'Missing option' in result.output or 'required' in result.output.lower()
+
+    @patch('ckanext.activityinfo.cli.resources.download_activityinfo_resource')
+    def test_verbose_flag(self, mock_download, setup_data):
+        """Verbose flag should not break the command."""
+        resource = factories.ActivityInfoResource()
+        user_name = setup_data.activityinfo_user['name']
+
+        runner = CliRunner()
+        result = runner.invoke(update_activityinfo_resource, [
+            '-r', resource['id'], '-u', user_name, '-v'
+        ])
+
+        assert result.exit_code == 0
+        assert 'updated successfully' in result.output
+
+
+# ---- sync-auto-updates ----
+
+@pytest.mark.usefixtures("clean_db")
+class TestSyncAutoUpdatesCLI:
+    """Tests for the sync-auto-updates CLI command."""
+
+    def test_no_due_resources(self, setup_data):
+        """When no resources are due, show appropriate message and exit 0."""
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert result.exit_code == 0
+        assert 'No resources due for update' in result.output
+
+    def test_never_resources_not_picked_up(self, setup_data):
+        """Resources with auto_update='never' should not be picked up."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='never',
+            activityinfo_user=setup_data.activityinfo_user['name'],
+        )
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert result.exit_code == 0
+        assert 'No resources due for update' in result.output
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_dry_run_shows_resources_without_updating(self, mock_get_action, setup_data):
+        """Dry run should list due resources but not enqueue jobs."""
+        user_name = setup_data.activityinfo_user['name']
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, ['--dry-run'])
+        assert result.exit_code == 0
+        assert 'DRY RUN' in result.output
+        assert resource['id'] in result.output
+        assert user_name in result.output
+        mock_get_action.assert_not_called()
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_skips_resource_without_activityinfo_user(self, mock_get_action, setup_data):
+        """Resources without activityinfo_user should be skipped."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user='',
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '1 skipped' in result.output
+        assert 'no activityinfo_user set' in result.output
+        mock_get_action.assert_not_called()
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_enqueues_job_for_due_resource(self, mock_get_action, setup_data):
+        """Due resources should be enqueued via act_info_update_resource_file."""
+        user_name = setup_data.activityinfo_user['name']
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        original_get_action = toolkit.get_action
+        action_calls = []
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                def fake_action(ctx, dd):
+                    action_calls.append({
+                        'user': ctx.get('user'),
+                        'resource_id': dd.get('resource_id'),
+                    })
+                    return {'job_id': 'test-job-123', 'resource_id': dd['resource_id']}
+                return fake_action
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert result.exit_code == 0
+        assert '1 enqueued' in result.output
+        assert 'test-job-123' in result.output
+
+        assert len(action_calls) == 1
+        assert action_calls[0]['user'] == user_name
+        assert action_calls[0]['resource_id'] == resource['id']
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_increments_counter_after_enqueue(self, mock_get_action, setup_data):
+        """Counter and timestamp should be updated after successful enqueue."""
+        user_name = setup_data.activityinfo_user['name']
+        before = datetime.now(timezone.utc)
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=2,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                return lambda ctx, dd: {'job_id': 'j', 'resource_id': dd['resource_id']}
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        runner.invoke(sync_auto_updates, [])
+
+        updated = original_get_action('resource_show')(
+            {'ignore_auth': True}, {'id': resource['id']}
+        )
+        assert int(updated['activityinfo_auto_update_count']) == 3
+        last_updated = datetime.fromisoformat(updated['activityinfo_last_updated'])
+        assert last_updated >= before
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_counter_unchanged_on_enqueue_failure(self, mock_get_action, setup_data):
+        """If enqueuing fails, counter should not be incremented."""
+        user_name = setup_data.activityinfo_user['name']
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=2,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                raise Exception("Connection refused")
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '1 failed' in result.output
+        assert 'Connection refused' in result.output
+
+        updated = original_get_action('resource_show')(
+            {'ignore_auth': True}, {'id': resource['id']}
+        )
+        assert int(updated['activityinfo_auto_update_count']) == 2
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_per_resource_user_isolation(self, mock_get_action, setup_data):
+        """Each resource should be updated using its own activityinfo_user."""
+        user_a = setup_data.activityinfo_user['name']
+        user_b = factories.ActivityInfoUser()['name']
+
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_a,
+        )
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_b,
+        )
+
+        users_called = []
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                def fake_action(ctx, dd):
+                    users_called.append(ctx.get('user'))
+                    return {'job_id': 'j', 'resource_id': dd['resource_id']}
+                return fake_action
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '2 enqueued' in result.output
+        assert set(users_called) == {user_a, user_b}
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_mixed_success_and_failure(self, mock_get_action, setup_data):
+        """Summary should correctly count mixed results."""
+        user_name = setup_data.activityinfo_user['name']
+
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+        # No user -> skipped
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user='',
+        )
+
+        call_count = [0]
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                def fake_action(ctx, dd):
+                    call_count[0] += 1
+                    if call_count[0] == 2:
+                        raise Exception("Boom")
+                    return {'job_id': 'j', 'resource_id': dd['resource_id']}
+                return fake_action
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '1 enqueued' in result.output
+        assert '1 failed' in result.output
+        assert '1 skipped' in result.output
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_recently_created_resource_not_due(self, mock_get_action, setup_data):
+        """A resource created just now (with last_updated set) should not be due."""
+        user_name = setup_data.activityinfo_user['name']
+        now = datetime.now(timezone.utc).isoformat()
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated=now,
+            activityinfo_user=user_name,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert result.exit_code == 0
+        assert 'No resources due for update' in result.output
+        mock_get_action.assert_not_called()

--- a/ckanext/activityinfo/tests/test_sync_auto_updates.py
+++ b/ckanext/activityinfo/tests/test_sync_auto_updates.py
@@ -12,6 +12,10 @@ from ckanext.activityinfo.cli.resources import sync_auto_updates
 from ckanext.activityinfo.tests import factories
 from ckanext.activityinfo.utils import get_resources_due_for_auto_update
 
+# Captured BEFORE any @patch of toolkit.get_action so tests can call the real
+# action dispatcher without re-entering the mock (which causes recursion).
+_REAL_GET_ACTION = toolkit.get_action
+
 
 @pytest.fixture
 def setup_data():
@@ -211,7 +215,7 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
         )
 
         # Mock only act_info_update_resource_file, let others pass through
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':
@@ -242,7 +246,7 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
             activityinfo_user=user_name,
         )
 
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':
@@ -280,7 +284,7 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
         # get_action should not have been called at all during dry run
         mock_get_action.assert_not_called()
 
-        updated = toolkit.get_action('resource_show')(
+        updated = _REAL_GET_ACTION('resource_show')(
             {'ignore_auth': True}, {'id': resource['id']}
         )
         assert int(updated['activityinfo_auto_update_count']) == 0
@@ -332,7 +336,7 @@ class TestSyncAutoUpdatesCLIOutput:
             activityinfo_user=user_name,
         )
 
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':
@@ -368,7 +372,7 @@ class TestSyncAutoUpdatesCLIOutput:
         )
 
         calls = []
-        original_get_action = toolkit.get_action
+        original_get_action = _REAL_GET_ACTION
 
         def selective_mock(action_name):
             if action_name == 'act_info_update_resource_file':

--- a/ckanext/activityinfo/tests/test_sync_auto_updates.py
+++ b/ckanext/activityinfo/tests/test_sync_auto_updates.py
@@ -1,0 +1,387 @@
+"""Tests for auto-update sync logic (utils + CLI command)."""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from ckan.plugins import toolkit
+from ckantoolkit.tests import factories as ckan_factories
+
+from ckanext.activityinfo.cli.resources import sync_auto_updates
+from ckanext.activityinfo.tests import factories
+from ckanext.activityinfo.utils import get_resources_due_for_auto_update
+
+
+@pytest.fixture
+def setup_data():
+    obj = SimpleNamespace()
+    obj.activityinfo_user = factories.ActivityInfoUser()
+    obj.regular_user = ckan_factories.UserWithToken()
+    return obj
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestGetResourcesDueForAutoUpdate:
+    """Tests for the get_resources_due_for_auto_update utility function."""
+
+    def test_no_resources(self, setup_data):
+        """No resources exist, should return empty list."""
+        result = get_resources_due_for_auto_update()
+        assert result == []
+
+    def test_resource_with_never_not_due(self, setup_data):
+        """Resources with auto_update='never' should not be due."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='never',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_daily_resource_never_updated_is_due(self, setup_data):
+        """A daily resource that was never updated should be due."""
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 1
+        assert result[0]['id'] == resource['id']
+
+    def test_weekly_resource_never_updated_is_due(self, setup_data):
+        """A weekly resource that was never updated should be due."""
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='weekly',
+            activityinfo_auto_update_runs=3,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 1
+        assert result[0]['id'] == resource['id']
+
+    def test_daily_resource_updated_recently_not_due(self, setup_data):
+        """A daily resource updated less than 24h ago should not be due."""
+        recent = (datetime.now(timezone.utc) - timedelta(hours=12)).isoformat()
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=1,
+            activityinfo_last_updated=recent,
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_daily_resource_updated_long_ago_is_due(self, setup_data):
+        """A daily resource updated more than 24h ago should be due."""
+        old = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=1,
+            activityinfo_last_updated=old,
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 1
+        assert result[0]['id'] == resource['id']
+
+    def test_weekly_resource_updated_3_days_ago_not_due(self, setup_data):
+        """A weekly resource updated 3 days ago should not be due."""
+        recent = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='weekly',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=1,
+            activityinfo_last_updated=recent,
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_weekly_resource_updated_8_days_ago_is_due(self, setup_data):
+        """A weekly resource updated 8 days ago should be due."""
+        old = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='weekly',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=1,
+            activityinfo_last_updated=old,
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 1
+        assert result[0]['id'] == resource['id']
+
+    def test_run_limit_reached_not_due(self, setup_data):
+        """A resource that reached its run limit should not be due."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=3,
+            activityinfo_auto_update_count=3,
+            activityinfo_last_updated='',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_run_limit_exceeded_not_due(self, setup_data):
+        """A resource that exceeded its run limit should not be due."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=2,
+            activityinfo_auto_update_count=5,
+            activityinfo_last_updated='',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_pending_resource_not_due(self, setup_data):
+        """A resource with status 'pending' should not be picked up."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_status='pending',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_error_resource_not_due(self, setup_data):
+        """A resource with status 'error' should not be picked up."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_status='error',
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 0
+
+    def test_multiple_resources_mixed(self, setup_data):
+        """Only due resources should be returned from a mixed set."""
+        # Due: daily, never updated
+        res_due = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+        )
+        # Not due: never
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='never',
+        )
+        # Not due: run limit reached
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=1,
+            activityinfo_auto_update_count=1,
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 1
+        assert result[0]['id'] == res_due['id']
+
+    def test_due_resource_includes_activityinfo_user(self, setup_data):
+        """Due resource dict should include activityinfo_user field."""
+        user_name = setup_data.activityinfo_user['name']
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+        result = get_resources_due_for_auto_update()
+        assert len(result) == 1
+        assert result[0]['activityinfo_user'] == user_name
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestSyncAutoUpdatesCounterAndTimestamp:
+    """Test that the sync command updates counter and timestamp correctly."""
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_counter_incremented_after_enqueue(self, mock_get_action, setup_data):
+        """After enqueuing a job, counter should be incremented."""
+        user_name = setup_data.activityinfo_user['name']
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        # Mock only act_info_update_resource_file, let others pass through
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                return lambda ctx, dd: {'job_id': 'test-job', 'resource_id': dd['resource_id']}
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert result.exit_code == 0
+
+        updated = original_get_action('resource_show')(
+            {'ignore_auth': True}, {'id': resource['id']}
+        )
+        assert int(updated['activityinfo_auto_update_count']) == 1
+        assert updated['activityinfo_last_updated'] != ''
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_counter_not_incremented_on_failure(self, mock_get_action, setup_data):
+        """If enqueuing fails, counter should not change."""
+        user_name = setup_data.activityinfo_user['name']
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=2,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                raise Exception("Enqueue failed")
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '1 failed' in result.output
+
+        updated = original_get_action('resource_show')(
+            {'ignore_auth': True}, {'id': resource['id']}
+        )
+        assert int(updated['activityinfo_auto_update_count']) == 2
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_dry_run_does_not_update(self, mock_get_action, setup_data):
+        """Dry run should not enqueue jobs or update anything."""
+        user_name = setup_data.activityinfo_user['name']
+        resource = factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, ['--dry-run'])
+        assert result.exit_code == 0
+        assert 'DRY RUN' in result.output
+
+        # get_action should not have been called at all during dry run
+        mock_get_action.assert_not_called()
+
+        updated = toolkit.get_action('resource_show')(
+            {'ignore_auth': True}, {'id': resource['id']}
+        )
+        assert int(updated['activityinfo_auto_update_count']) == 0
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_resource_without_user_is_skipped(self, mock_get_action, setup_data):
+        """Resources with no activityinfo_user should be skipped."""
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user='',
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '1 skipped' in result.output
+        mock_get_action.assert_not_called()
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestSyncAutoUpdatesCLIOutput:
+    """Test CLI output messages."""
+
+    def test_no_resources_message(self, setup_data):
+        """When no resources are due, show appropriate message."""
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert result.exit_code == 0
+        assert 'No resources due for update' in result.output
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_summary_shows_counts(self, mock_get_action, setup_data):
+        """Summary should show enqueued and failed counts."""
+        user_name = setup_data.activityinfo_user['name']
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_name,
+        )
+
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                return lambda ctx, dd: {'job_id': 'test-job', 'resource_id': dd['resource_id']}
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        result = runner.invoke(sync_auto_updates, [])
+        assert '2 enqueued' in result.output
+        assert '0 failed' in result.output
+
+    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
+    def test_uses_per_resource_user(self, mock_get_action, setup_data):
+        """Each resource should use its own activityinfo_user."""
+        user_a = setup_data.activityinfo_user['name']
+        user_b = factories.ActivityInfoUser()['name']
+
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_a,
+        )
+        factories.ActivityInfoResource(
+            activityinfo_auto_update='daily',
+            activityinfo_auto_update_runs=5,
+            activityinfo_auto_update_count=0,
+            activityinfo_last_updated='',
+            activityinfo_user=user_b,
+        )
+
+        calls = []
+        original_get_action = toolkit.get_action
+
+        def selective_mock(action_name):
+            if action_name == 'act_info_update_resource_file':
+                def fake_action(ctx, dd):
+                    calls.append(ctx.get('user'))
+                    return {'job_id': 'test-job', 'resource_id': dd['resource_id']}
+                return fake_action
+            return original_get_action(action_name)
+
+        mock_get_action.side_effect = selective_mock
+
+        runner = CliRunner()
+        runner.invoke(sync_auto_updates, [])
+
+        assert len(calls) == 2
+        assert set(calls) == {user_a, user_b}

--- a/ckanext/activityinfo/tests/test_sync_auto_updates.py
+++ b/ckanext/activityinfo/tests/test_sync_auto_updates.py
@@ -1,7 +1,7 @@
 """Tests for auto-update sync logic (utils + CLI command)."""
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
@@ -11,10 +11,6 @@ from ckantoolkit.tests import factories as ckan_factories
 from ckanext.activityinfo.cli.resources import sync_auto_updates
 from ckanext.activityinfo.tests import factories
 from ckanext.activityinfo.utils import get_resources_due_for_auto_update
-
-# Captured BEFORE any @patch of toolkit.get_action so tests can call the real
-# action dispatcher without re-entering the mock (which causes recursion).
-_REAL_GET_ACTION = toolkit.get_action
 
 
 @pytest.fixture
@@ -202,8 +198,7 @@ class TestGetResourcesDueForAutoUpdate:
 class TestSyncAutoUpdatesCounterAndTimestamp:
     """Test that the sync command updates counter and timestamp correctly."""
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_counter_incremented_after_enqueue(self, mock_get_action, setup_data):
+    def test_counter_incremented_after_enqueue(self, setup_data):
         """After enqueuing a job, counter should be incremented."""
         user_name = setup_data.activityinfo_user['name']
         resource = factories.ActivityInfoResource(
@@ -214,28 +209,25 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
             activityinfo_user=user_name,
         )
 
-        # Mock only act_info_update_resource_file, let others pass through
-        original_get_action = _REAL_GET_ACTION
+        def fake_update(ctx, dd):
+            return {'job_id': 'test-job', 'resource_id': dd['resource_id']}
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                return lambda ctx, dd: {'job_id': 'test-job', 'resource_id': dd['resource_id']}
-            return original_get_action(action_name)
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        mock_get_action.side_effect = selective_mock
-
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert result.exit_code == 0
 
-        updated = original_get_action('resource_show')(
+        updated = toolkit.get_action('resource_show')(
             {'ignore_auth': True}, {'id': resource['id']}
         )
         assert int(updated['activityinfo_auto_update_count']) == 1
         assert updated['activityinfo_last_updated'] != ''
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_counter_not_incremented_on_failure(self, mock_get_action, setup_data):
+    def test_counter_not_incremented_on_failure(self, setup_data):
         """If enqueuing fails, counter should not change."""
         user_name = setup_data.activityinfo_user['name']
         resource = factories.ActivityInfoResource(
@@ -246,26 +238,24 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
             activityinfo_user=user_name,
         )
 
-        original_get_action = _REAL_GET_ACTION
+        def fake_update(ctx, dd):
+            raise Exception("Enqueue failed")
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                raise Exception("Enqueue failed")
-            return original_get_action(action_name)
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        mock_get_action.side_effect = selective_mock
-
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert '1 failed' in result.output
 
-        updated = original_get_action('resource_show')(
+        updated = toolkit.get_action('resource_show')(
             {'ignore_auth': True}, {'id': resource['id']}
         )
         assert int(updated['activityinfo_auto_update_count']) == 2
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_dry_run_does_not_update(self, mock_get_action, setup_data):
+    def test_dry_run_does_not_update(self, setup_data):
         """Dry run should not enqueue jobs or update anything."""
         user_name = setup_data.activityinfo_user['name']
         resource = factories.ActivityInfoResource(
@@ -276,21 +266,24 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
             activityinfo_user=user_name,
         )
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, ['--dry-run'])
+        fake_update = mock.MagicMock()
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, ['--dry-run'])
+
         assert result.exit_code == 0
         assert 'DRY RUN' in result.output
+        fake_update.assert_not_called()
 
-        # get_action should not have been called at all during dry run
-        mock_get_action.assert_not_called()
-
-        updated = _REAL_GET_ACTION('resource_show')(
+        updated = toolkit.get_action('resource_show')(
             {'ignore_auth': True}, {'id': resource['id']}
         )
         assert int(updated['activityinfo_auto_update_count']) == 0
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_resource_without_user_is_skipped(self, mock_get_action, setup_data):
+    def test_resource_without_user_is_skipped(self, setup_data):
         """Resources with no activityinfo_user should be skipped."""
         factories.ActivityInfoResource(
             activityinfo_auto_update='daily',
@@ -300,10 +293,16 @@ class TestSyncAutoUpdatesCounterAndTimestamp:
             activityinfo_user='',
         )
 
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
+        fake_update = mock.MagicMock()
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
+
         assert '1 skipped' in result.output
-        mock_get_action.assert_not_called()
+        fake_update.assert_not_called()
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -317,8 +316,7 @@ class TestSyncAutoUpdatesCLIOutput:
         assert result.exit_code == 0
         assert 'No resources due for update' in result.output
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_summary_shows_counts(self, mock_get_action, setup_data):
+    def test_summary_shows_counts(self, setup_data):
         """Summary should show enqueued and failed counts."""
         user_name = setup_data.activityinfo_user['name']
         factories.ActivityInfoResource(
@@ -336,22 +334,20 @@ class TestSyncAutoUpdatesCLIOutput:
             activityinfo_user=user_name,
         )
 
-        original_get_action = _REAL_GET_ACTION
+        def fake_update(ctx, dd):
+            return {'job_id': 'test-job', 'resource_id': dd['resource_id']}
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                return lambda ctx, dd: {'job_id': 'test-job', 'resource_id': dd['resource_id']}
-            return original_get_action(action_name)
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(sync_auto_updates, [])
 
-        mock_get_action.side_effect = selective_mock
-
-        runner = CliRunner()
-        result = runner.invoke(sync_auto_updates, [])
         assert '2 enqueued' in result.output
         assert '0 failed' in result.output
 
-    @patch('ckanext.activityinfo.cli.resources.toolkit.get_action')
-    def test_uses_per_resource_user(self, mock_get_action, setup_data):
+    def test_uses_per_resource_user(self, setup_data):
         """Each resource should use its own activityinfo_user."""
         user_a = setup_data.activityinfo_user['name']
         user_b = factories.ActivityInfoUser()['name']
@@ -372,20 +368,17 @@ class TestSyncAutoUpdatesCLIOutput:
         )
 
         calls = []
-        original_get_action = _REAL_GET_ACTION
 
-        def selective_mock(action_name):
-            if action_name == 'act_info_update_resource_file':
-                def fake_action(ctx, dd):
-                    calls.append(ctx.get('user'))
-                    return {'job_id': 'test-job', 'resource_id': dd['resource_id']}
-                return fake_action
-            return original_get_action(action_name)
+        def fake_update(ctx, dd):
+            calls.append(ctx.get('user'))
+            return {'job_id': 'test-job', 'resource_id': dd['resource_id']}
 
-        mock_get_action.side_effect = selective_mock
-
-        runner = CliRunner()
-        runner.invoke(sync_auto_updates, [])
+        with mock.patch.dict(
+            'ckan.logic._actions',
+            {'act_info_update_resource_file': fake_update},
+        ):
+            runner = CliRunner()
+            runner.invoke(sync_auto_updates, [])
 
         assert len(calls) == 2
         assert set(calls) == {user_a, user_b}

--- a/ckanext/activityinfo/utils.py
+++ b/ckanext/activityinfo/utils.py
@@ -215,6 +215,147 @@ def get_resources_due_for_auto_update():
     return due_resources
 
 
+def run_sync_auto_updates(dry_run=False):
+    """Find resources due for auto-update and enqueue download jobs.
+
+    Pure function with no CLI dependencies. Emits progress via ``log.info`` /
+    ``log.error``; pair with ``setup_cli_logging`` to get live CLI output, or
+    call from another extension (e.g. ckanext-unhcr) to log outcomes to a
+    system activity record.
+
+    Args:
+        dry_run: If True, do not enqueue jobs, just list what would be done.
+
+    Returns:
+        A summary dict:
+            {
+                'dry_run': bool,
+                'total_due': int,
+                'enqueued': int,
+                'failed': int,
+                'skipped': int,
+                'details': [ {resource_id, form_label, user, status, ...}, ... ],
+                'finished': bool,
+            }
+    """
+    summary = {
+        'dry_run': dry_run,
+        'total_due': 0,
+        'enqueued': 0,
+        'failed': 0,
+        'skipped': 0,
+        'details': [],
+        'finished': False,
+    }
+
+    log.info("Checking for ActivityInfo resources due for auto-update...")
+    due_resources = get_resources_due_for_auto_update()
+    summary['total_due'] = len(due_resources)
+
+    if not due_resources:
+        log.info("No resources due for update.")
+        summary['finished'] = True
+        return summary
+
+    log.info(f"Found {len(due_resources)} resource(s) due for update.")
+
+    if dry_run:
+        for res in due_resources:
+            count = res.get('activityinfo_auto_update_count', 0)
+            max_runs = res.get('activityinfo_auto_update_runs', 1)
+            user = res.get('activityinfo_user', '?')
+            log.info(
+                f"[DRY RUN] {res['id']} - "
+                f"{res.get('activityinfo_form_label', '?')} "
+                f"({res.get('activityinfo_auto_update')}, "
+                f"run {count}/{max_runs}, user: {user})"
+            )
+            summary['details'].append({
+                'resource_id': res['id'],
+                'form_label': res.get('activityinfo_form_label', '?'),
+                'user': user,
+                'status': 'dry-run',
+            })
+        summary['finished'] = True
+        return summary
+
+    for res in due_resources:
+        resource_id = res['id']
+        form_label = res.get('activityinfo_form_label', resource_id)
+        current_count = _safe_int(res.get('activityinfo_auto_update_count'), 0)
+        max_runs = _safe_int(res.get('activityinfo_auto_update_runs'), 1)
+        user_name = res.get('activityinfo_user')
+
+        if not user_name:
+            log.info(
+                f"Skipping: {form_label} ({resource_id}) "
+                f"- no activityinfo_user set"
+            )
+            summary['skipped'] += 1
+            summary['details'].append({
+                'resource_id': resource_id,
+                'form_label': form_label,
+                'status': 'skipped',
+                'reason': 'no activityinfo_user set',
+            })
+            continue
+
+        log.info(
+            f"Updating: {form_label} ({resource_id}) "
+            f"- run {current_count + 1}/{max_runs}, user: {user_name}"
+        )
+
+        try:
+            result = toolkit.get_action('act_info_update_resource_file')(
+                {'user': user_name, 'ignore_auth': True},
+                {'resource_id': resource_id}
+            )
+
+            # Update the counter and timestamp now that the job is enqueued.
+            # We count this as a run even if the background job later fails,
+            # to avoid infinite retries. Errors will be captured in the
+            # activityinfo_error resource extra field by the download job.
+            now_iso = datetime.now(timezone.utc).isoformat()
+            toolkit.get_action('resource_patch')(
+                {'user': user_name, 'ignore_auth': True},
+                {
+                    'id': resource_id,
+                    'activityinfo_last_updated': now_iso,
+                    'activityinfo_auto_update_count': current_count + 1,
+                }
+            )
+
+            job_id = result.get('job_id', '?')
+            log.info(
+                f"OK - job {job_id} enqueued "
+                f"(run {current_count + 1}/{max_runs})"
+            )
+            summary['enqueued'] += 1
+            summary['details'].append({
+                'resource_id': resource_id,
+                'form_label': form_label,
+                'user': user_name,
+                'status': 'enqueued',
+                'job_id': job_id,
+                'run': current_count + 1,
+                'max_runs': max_runs,
+            })
+
+        except Exception as e:
+            log.error(f"FAILED - {e}")
+            summary['failed'] += 1
+            summary['details'].append({
+                'resource_id': resource_id,
+                'form_label': form_label,
+                'user': user_name,
+                'status': 'failed',
+                'error': str(e),
+            })
+
+    summary['finished'] = True
+    return summary
+
+
 def _safe_int(value, default=0):
     """Safely convert a value to int, returning default on failure."""
     if value is None or value == '':

--- a/ckanext/activityinfo/utils.py
+++ b/ckanext/activityinfo/utils.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta, timezone
 from functools import wraps
 from ckan.plugins import toolkit
 from ckan import model
-from sqlalchemy import and_
+from sqlalchemy import and_, cast
+from sqlalchemy.dialects.postgresql import JSONB
 
 
 log = logging.getLogger(__name__)
@@ -12,6 +13,10 @@ log = logging.getLogger(__name__)
 # 'never' means auto-update is disabled.
 VALID_AUTO_UPDATE_VALUES = ('never', 'daily', 'weekly')
 SCHEDULABLE_AUTO_UPDATE_VALUES = ('daily', 'weekly')
+
+# Resource.extras is stored as UnicodeText (JSON string), not native JSONB.
+# Cast it to JSONB so we can use PostgreSQL JSON operators in queries.
+_extras_jsonb = cast(model.Resource.extras, JSONB)
 
 
 def get_activity_info_user_plugin_extras(user_name_or_id):
@@ -61,7 +66,7 @@ def get_ckan_resources(form_id):
     resources = model.Session.query(model.Resource).filter(
         and_(
             model.Resource.state == 'active',
-            model.Resource.extras['activityinfo_form_id'].astext == form_id,
+            _extras_jsonb['activityinfo_form_id'].astext == form_id,
         )
     ).all()
 
@@ -91,7 +96,7 @@ def get_ai_resources(limit=100):
     resources = model.Session.query(model.Resource).filter(
         and_(
             model.Resource.state == 'active',
-            model.Resource.extras['activityinfo_status'].astext == 'complete',
+            _extras_jsonb['activityinfo_status'].astext == 'complete',
         )
     ).limit(limit).all()
 
@@ -161,8 +166,8 @@ def get_resources_due_for_auto_update():
     resources = model.Session.query(model.Resource).filter(
         and_(
             model.Resource.state == 'active',
-            model.Resource.extras['activityinfo_status'].astext == 'complete',
-            model.Resource.extras['activityinfo_auto_update'].astext.in_(
+            _extras_jsonb['activityinfo_status'].astext == 'complete',
+            _extras_jsonb['activityinfo_auto_update'].astext.in_(
                 SCHEDULABLE_AUTO_UPDATE_VALUES
             ),
         )

--- a/ckanext/activityinfo/utils.py
+++ b/ckanext/activityinfo/utils.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from ckan.plugins import toolkit
 from ckan import model
@@ -6,6 +7,11 @@ from sqlalchemy import and_
 
 
 log = logging.getLogger(__name__)
+
+# Valid values for the activityinfo_auto_update field.
+# 'never' means auto-update is disabled.
+VALID_AUTO_UPDATE_VALUES = ('never', 'daily', 'weekly')
+SCHEDULABLE_AUTO_UPDATE_VALUES = ('daily', 'weekly')
 
 
 def get_activity_info_user_plugin_extras(user_name_or_id):
@@ -51,22 +57,26 @@ def get_ckan_resources(form_id):
         form_id: The ActivityInfo form ID
     Returns:
         A list of tuples (resource_name, resource_url)
-
     """
-    search_dict = {'query': f'activityinfo_form_id:{form_id}'}
-    resources = toolkit.get_action('resource_search')({'ignore_auth': True}, search_dict)
+    resources = model.Session.query(model.Resource).filter(
+        and_(
+            model.Resource.state == 'active',
+            model.Resource.extras['activityinfo_form_id'].astext == form_id,
+        )
+    ).all()
+
     ret = []
-    if resources.get('count', 0) > 0:
-        results = resources['results']
-        for res in results:
-            pkg = toolkit.get_action('package_show')(
-                {'ignore_auth': True}, {'id': res['package_id']}
-            )
-            pkg_type = pkg.get('type', 'dataset')
-            resource_url = toolkit.url_for(f'{pkg_type}_resource.read', id=pkg['name'], resource_id=res['id'])
-            ret.append(
-                (res.get('name', 'Unnamed resource'), resource_url)
-            )
+    for res in resources:
+        pkg = toolkit.get_action('package_show')(
+            {'ignore_auth': True}, {'id': res.package_id}
+        )
+        pkg_type = pkg.get('type', 'dataset')
+        resource_url = toolkit.url_for(
+            f'{pkg_type}_resource.read', id=pkg['name'], resource_id=res.id
+        )
+        ret.append(
+            (res.name or 'Unnamed resource', resource_url)
+        )
 
     return ret
 
@@ -77,25 +87,27 @@ def get_ai_resources(limit=100):
         limit: Maximum number of resources to return, default 100
     Returns:
         A list of resources with their URLs
-
     """
-    search_dict = {
-        'query': 'activityinfo_status:complete',
-        'limit': limit,
-    }
-    resources = toolkit.get_action('resource_search')({'ignore_auth': True}, search_dict)
+    resources = model.Session.query(model.Resource).filter(
+        and_(
+            model.Resource.state == 'active',
+            model.Resource.extras['activityinfo_status'].astext == 'complete',
+        )
+    ).limit(limit).all()
+
     ret = []
-    if resources.get('count', 0) > 0:
-        results = resources['results']
-        for res in results:
-            pkg = toolkit.get_action('package_show')(
-                {'ignore_auth': True}, {'id': res['package_id']}
-            )
-            pkg_type = pkg.get('type', 'dataset')
-            resource_url = toolkit.url_for(f'{pkg_type}_resource.read', id=pkg['name'], resource_id=res['id'])
-            res['final_url'] = resource_url
-            res['package'] = pkg
-            ret.append(res)
+    for res in resources:
+        pkg = toolkit.get_action('package_show')(
+            {'ignore_auth': True}, {'id': res.package_id}
+        )
+        pkg_type = pkg.get('type', 'dataset')
+        resource_url = toolkit.url_for(
+            f'{pkg_type}_resource.read', id=pkg['name'], resource_id=res.id
+        )
+        res_dict = res.as_dict()
+        res_dict['final_url'] = resource_url
+        res_dict['package'] = pkg
+        ret.append(res_dict)
 
     return ret
 
@@ -128,6 +140,84 @@ def get_users_with_activity_info_token():
         })
 
     return final_users
+
+
+def get_resources_due_for_auto_update():
+    """Find all ActivityInfo resources that are due for automatic update.
+
+    A resource is due when:
+    - activityinfo_auto_update is 'daily' or 'weekly'
+    - activityinfo_status is 'complete' (not currently processing)
+    - activityinfo_auto_update_count < activityinfo_auto_update_runs
+    - Enough time has passed since activityinfo_last_updated
+      (24h for daily, 7 days for weekly), or never updated yet
+
+    Returns:
+        A list of resource dicts that need updating.
+    """
+    now = datetime.now(timezone.utc)
+
+    # Query resources with auto-update enabled and status complete
+    resources = model.Session.query(model.Resource).filter(
+        and_(
+            model.Resource.state == 'active',
+            model.Resource.extras['activityinfo_status'].astext == 'complete',
+            model.Resource.extras['activityinfo_auto_update'].astext.in_(
+                SCHEDULABLE_AUTO_UPDATE_VALUES
+            ),
+        )
+    ).all()
+
+    due_resources = []
+    for res in resources:
+        extras = res.extras or {}
+        frequency = extras.get('activityinfo_auto_update')
+        max_runs = _safe_int(extras.get('activityinfo_auto_update_runs'), 1)
+        current_count = _safe_int(extras.get('activityinfo_auto_update_count'), 0)
+
+        # Check run limit
+        if current_count >= max_runs:
+            log.debug(
+                f"Skipping resource {res.id}: "
+                f"run limit reached ({current_count}/{max_runs})"
+            )
+            continue
+
+        # Check timing
+        last_updated = extras.get('activityinfo_last_updated')
+        if last_updated:
+            try:
+                last_dt = datetime.fromisoformat(last_updated)
+                if last_dt.tzinfo is None:
+                    last_dt = last_dt.replace(tzinfo=timezone.utc)
+                if frequency == 'daily' and (now - last_dt) < timedelta(hours=24):
+                    log.debug(
+                        f"Skipping resource {res.id}: "
+                        f"last updated {last_updated}, not yet due (daily)"
+                    )
+                    continue
+                if frequency == 'weekly' and (now - last_dt) < timedelta(days=7):
+                    log.debug(
+                        f"Skipping resource {res.id}: "
+                        f"last updated {last_updated}, not yet due (weekly)"
+                    )
+                    continue
+            except (ValueError, TypeError):
+                pass
+
+        due_resources.append(res.as_dict())
+
+    return due_resources
+
+
+def _safe_int(value, default=0):
+    """Safely convert a value to int, returning default on failure."""
+    if value is None or value == '':
+        return default
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
 
 
 def require_sysadmin_user(func):

--- a/test.ini
+++ b/test.ini
@@ -10,7 +10,7 @@ use = config:../ckan/test-core.ini
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = activityinfo
 
-ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count activityinfo_user
+ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_progress activityinfo_error activityinfo_format activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count activityinfo_user
 
 # Logging configuration
 [loggers]

--- a/test.ini
+++ b/test.ini
@@ -10,7 +10,7 @@ use = config:../ckan/test-core.ini
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = activityinfo
 
-ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count
+ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count activityinfo_user
 
 # Logging configuration
 [loggers]

--- a/test.ini
+++ b/test.ini
@@ -10,7 +10,7 @@ use = config:../ckan/test-core.ini
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = activityinfo
 
-ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs
+ckan.extra_resource_fields = activityinfo_form_id activityinfo_database_id activityinfo_form_label activityinfo_status activityinfo_auto_update activityinfo_auto_update_runs activityinfo_last_updated activityinfo_auto_update_count
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Allow running automatic updates.
Users will need to schedule hourly/daily runs of this new command as described in the README

Also:
 - leave `resource_search` CKAN function because it's not a good function for searching
 - Improve cli command logging because _why not_
